### PR TITLE
Add support for pulling content from different Prismic refs

### DIFF
--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -223,6 +223,35 @@ export default function Example({ data, prismic }) {
 }
 ```
 
+### Prismic.io content a/b experiments integration
+
+You can use this plugin in combination with Prismic's built-in experiments functionality, and a hosting service like Netlify, to run content a/b tests.
+
+Experiments in Prismic are basically branches of the core content, split into 'refs' similar to git branches.
+So if you want to get content from a certain experiment variation, you can pass the corresponding ref through to Prismic in your request,
+and it will return content based on that ref's variation.
+
+A/B experiments are tricky to implement in a static website though; a/b testing needs a way to dynamically serve up the different variations
+to different website visitors. This is at odds with the idea of a static, non-dynamic website.
+
+Fortunately, static hosting providers like Netlify allow you to run a/b tests at a routing level.
+This makes it possible for us to build multiple versions of our project using different source data, and then within Netlify
+split traffic to our different static variations.
+
+Therefore, we can use a/b experiments from Prismic in the following way:
+
+1. Setup an experiment in Prismic.
+
+2. Create a new git branch of your project which will be used to get content. You will need to create a separate git branch for each variation.
+
+3. In that git branch, edit/add the optional 'prismicRef' parameter (documented above). The value of this should be the ref of the variation this git branch is for.
+
+4. Push the newly created branch to your git repo.
+
+5. Now go to your static hosting provider (we'll use Netlify in this example), and setup split testing based on your git branches/Prismic variations.
+
+6. Now your static website will show different experimental variations of the content to different users! At this point the process is manual and non-ideal, but hopefully we'll be able to automate it more in the future.
+
 ## How this plugin works
 
 1. The plugin creates a new page at `/preview` (by default, you can change this), that will be your preview URL you setup in the Prismic admin interface.

--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -25,6 +25,7 @@ Add plugin to `gatsby-config.js`:
   options: {
     repositoryName: 'gatsby-source-prismic-test-site', // (required)
     accessToken: '...', // (optional)
+    prismicRef: '...', // (optional, if not used then defaults to master ref. This option is useful for a/b experiments)
     path: '/preview', // (optional, default: /preview)
     previews: true, // (optional, default: false)
     pages: [{ // (optional)

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -18,7 +18,7 @@ exports.onCreatePage = ({ page, actions }: any) => {
 
 exports.sourceNodes = (
   ref: any,
-  options: { [key: string]: any; accessToken?: string; repositoryName: string }
+  options: { [key: string]: any; accessToken?: string; customRef?: string; repositoryName: string }
 ) => {
   options.fieldName = fieldName;
   options.typeName = typeName;
@@ -27,6 +27,7 @@ exports.sourceNodes = (
       uri: `https://${options.repositoryName}.prismic.io/graphql`,
       credentials: 'same-origin',
       accessToken: options.accessToken,
+      customRef: options.prismicRef,
     });
 
   return sourceNodes(ref, options);

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -18,7 +18,7 @@ exports.onCreatePage = ({ page, actions }: any) => {
 
 exports.sourceNodes = (
   ref: any,
-  options: { [key: string]: any; accessToken?: string; customRef?: string; repositoryName: string }
+  options: { [key: string]: any; accessToken?: string; prismicRef?: string; repositoryName: string }
 ) => {
   options.fieldName = fieldName;
   options.typeName = typeName;

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -9,6 +9,7 @@ interface Page {
 export interface PluginOptions {
   repositoryName: string;
   accessToken?: null | string;
+  prismicRef?: null | string;
   linkResolver?: Function;
   defaultLang?: string;
   passContextKeys?: string[];

--- a/packages/gatsby-source-prismic-graphql/src/utils/index.ts
+++ b/packages/gatsby-source-prismic-graphql/src/utils/index.ts
@@ -7,6 +7,7 @@ import { parseQueryString } from './parseQueryString';
 interface IPrismicLinkArgs extends HttpOptions {
   uri: string;
   accessToken?: string;
+  customRef?: string;
   credentials?: string;
   useGETForQueries?: boolean;
 }
@@ -44,7 +45,7 @@ export function fetchStripQueryWhitespace(url: string, ...args: any) {
  * Apollo Link for Prismic
  * @param options Options
  */
-export function PrismicLink({ uri, accessToken, ...rest }: IPrismicLinkArgs) {
+export function PrismicLink({ uri, accessToken, customRef, ...rest }: IPrismicLinkArgs) {
   const BaseURIReg = /^(https?:\/\/.+?\..+?\..+?)\/graphql\/?$/;
   const matches = uri.match(BaseURIReg);
   if (matches && matches[1]) {

--- a/packages/gatsby-source-prismic-graphql/src/utils/index.ts
+++ b/packages/gatsby-source-prismic-graphql/src/utils/index.ts
@@ -66,6 +66,10 @@ export function PrismicLink({ uri, accessToken, customRef, ...rest }: IPrismicLi
           prismicRef = api.masterRef.ref;
         }
         const authorizationHeader = accessToken ? { Authorization: `Token ${accessToken}` } : {};
+
+        // if custom ref has been defined, then use that to pull content instead of default master ref
+        prismicRef = (typeof customRef === 'undefined' || customRef === null) ? prismicRef : customRef;
+
         return {
           headers: {
             ...options.headers,


### PR DESCRIPTION
These changes add a new optional parameter to the plugin settings: prismicRef. This option allows devs to pass in a specific ref (e.g. of a Prismic a/b experiment), and the plugin will then source content from that ref instead of master.

If the parameter isn't specified, the plugin continues to act as before; pulling content from master by default.

This new optional parameter is useful because it enables production a/b testing of content. As documented in the updated Readme, a new (manual, for now) process is available for:

1. Starting an a/b experiment in Prismic
2. Creating 1:1 git branches corresponding to the experiment variations (each branch has prismicRef set to the variation ref)
3. And then hosting these different branches as a/b variations on the live production site (e.g. using Netlify's split testing feature)

The end result is a GatsbyJS website, with content sourced from Prismic, able to live preview on the production website, and now able to also run a/b content tests on production!

Thanks for your great work on setting up this plugin - I hope this pull request fits in with and contributes to your vision for it!