### PR TITLE
Fix issue preventing generation of more than 20 pages per type

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -33,9 +33,44 @@ exports.sourceNodes = (
   return sourceNodes(ref, options);
 };
 
+const getPagesQuery = ({ pageType }: { pageType: string }) => `
+  query AllPagesQuery (
+    $after: String
+  ) {
+    prismic {
+      ${pageType} (
+        first: 20
+        after: $after
+      ) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            _meta {
+              id
+              lang
+              uid
+              alternateLanguages {
+                id
+                lang
+                type
+                uid
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 exports.createPages = async ({ graphql, actions: { createPage } }: any, options: PluginOptions) => {
   const previewPath = options.previewPath || '/preview';
 
+  // Create top-level preview page
   createPage({
     path: previewPath.replace(/^\//, ''),
     component: path.resolve(path.join(__dirname, 'components', 'PreviewPage.js')),
@@ -44,64 +79,49 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     },
   });
 
-  await Promise.all(
-    (options.pages || []).map(async page => {
-      const queryKey = `all${page.type}s`;
-      const query = `
-      query {
-        prismic {
-          ${queryKey} {
-            edges {
-              node {
-                _meta {
-                  id
-                  lang
-                  uid
-                  alternateLanguages {
-                    id
-                    lang
-                    type
-                    uid
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
+  // Helper that recursively creates 20 pages at a time for the given page type
+  // (Prismic GraphQL queries only return up to 20 results per query)
+  async function createPageRecursively(page: any, endCursor: string = '') {
+    const pageType = `all${page.type}s`;
+    const query = getPagesQuery({ pageType });
+    const { data, errors } = await graphql(query, { after: endCursor });
+    const toPath = pathToRegexp.compile(page.match || page.path);
+    const rootQuery = getRootQuery(page.component);
 
-      const { data, errors } = await graphql(query);
-      const toPath = pathToRegexp.compile(page.match || page.path);
-      const rootQuery = getRootQuery(page.component);
+    if (errors && errors.length) {
+      throw errors[0];
+    }
 
-      if (errors && errors.length) {
-        throw errors[0];
+    const hasNextPage = data.prismic[pageType].pageInfo.hasNextPage;
+    endCursor = data.prismic[pageType].pageInfo.endCursor;
+
+    // Cycle through each page returned from query...
+    data.prismic[pageType].edges.forEach(({ node }: any) => {
+      const params = {
+        ...node._meta,
+        lang: node._meta.lang === options.defaultLang ? null : node._meta.lang,
+      };
+      const path = toPath(params);
+
+      if (page.lang && page.lang !== node._meta.lang) {
+        return; // don't generate page in other than set language
       }
 
-      data.prismic[queryKey].edges.forEach(({ node }: any) => {
-        const params = {
+      // ...and create the page
+      createPage({
+        path: path === '' ? '/' : path,
+        component: page.component,
+        context: {
+          rootQuery,
           ...node._meta,
-          lang: node._meta.lang === options.defaultLang ? null : node._meta.lang,
-        };
-        const path = toPath(params);
-
-        if (page.lang && page.lang !== node._meta.lang) {
-          // don't generate page in other than set language.
-          return;
-        }
-
-        createPage({
-          path: path === '' ? '/' : path,
-          component: page.component,
-          context: {
-            rootQuery,
-            ...node._meta,
-          },
-        });
+        },
       });
+    });
 
-      // used for preview placeholder page
+    if (hasNextPage) {
+      await createPageRecursively(page, endCursor);
+    } else {
+      // If there are no more pages, create the preview page for this page type
       createPage({
         path: page.path,
         matchPath: process.env.NODE_ENV === 'production' ? undefined : page.match,
@@ -113,6 +133,11 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
           lang: options.defaultLang,
         },
       });
-    })
-  );
+    }
+  }
+
+  // Create all the pages!
+  const pages = options.pages || [];
+  const pageCreators = pages.map(page => createPageRecursively(page));
+  await Promise.all(pageCreators);
 };

--- a/packages/gatsby-source-prismic-graphql/src/utils/index.ts
+++ b/packages/gatsby-source-prismic-graphql/src/utils/index.ts
@@ -31,7 +31,12 @@ export function fetchStripQueryWhitespace(url: string, ...args: any) {
   const [hostname, qs = ''] = url.split('?');
   const queryString = parseQueryString(qs);
   if (queryString.has('query')) {
-    queryString.set('query', String(queryString.get('query')).replace(/\#.*\n/g, '').replace(/\s+/g, ' '));
+    queryString.set(
+      'query',
+      String(queryString.get('query'))
+        .replace(/\#.*\n/g, '')
+        .replace(/\s+/g, ' ')
+    );
   }
   const updatedQs = Array.from(queryString)
     .map(n => n.map(j => encodeURIComponent(j)).join('='))
@@ -68,7 +73,8 @@ export function PrismicLink({ uri, accessToken, customRef, ...rest }: IPrismicLi
         const authorizationHeader = accessToken ? { Authorization: `Token ${accessToken}` } : {};
 
         // if custom ref has been defined, then use that to pull content instead of default master ref
-        prismicRef = (typeof customRef === 'undefined' || customRef === null) ? prismicRef : customRef;
+        prismicRef =
+          typeof customRef === 'undefined' || customRef === null ? prismicRef : customRef;
 
         return {
           headers: {


### PR DESCRIPTION
The Prismic GraphQL API limits all queries to 20 objects. This issue has been reported on this repo in Issue #24.

For each page type, `gatsby-node.ts` was requesting all pages in a single GraphQL query. This would only ever return 20 results. Instead of checking for more pages, it stopped there.

This PR addresses the issue by checking the `pageInfo.hasNextPage` property on the query response. If it is `true`,  it passes the `pageInfo.endCursor` into a subsequent query, recursively, and creates more pages...until `hasNextPage` is false.