### PR TITLE
Support Static Pagination; Fix Dynamic Pagination

### DIFF
--- a/examples/languages/gatsby-config.js
+++ b/examples/languages/gatsby-config.js
@@ -10,6 +10,7 @@ module.exports = {
       options: {
         repositoryName: 'ueno-starter-kit-universally-test',
         defaultLang: 'en-us',
+        langs: ['en-us', 'is'],
         pages: [
           {
             type: 'Homepage',

--- a/examples/pagination/src/pages/index.js
+++ b/examples/pagination/src/pages/index.js
@@ -1,6 +1,7 @@
 import { graphql, Link } from 'gatsby';
 import { get } from 'lodash';
 import React, { useEffect, useRef } from 'react';
+import { getCursorFromDocumentIndex } from 'gatsby-source-prismic-graphql';
 import Layout from '../components/layout';
 
 export const query = graphql`
@@ -46,7 +47,7 @@ const Home = props => {
     }
 
     props.prismic
-      .load({ variables: { after: btoa(`arrayconnection:${page}`) } })
+      .load({ variables: { after: getCursorFromDocumentIndex(page) } })
       .then(res => setData(res.data));
   }, [page]);
 

--- a/examples/pagination/src/pages/index.js
+++ b/examples/pagination/src/pages/index.js
@@ -1,6 +1,6 @@
 import { graphql, Link } from 'gatsby';
 import { get } from 'lodash';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Layout from '../components/layout';
 
 export const query = graphql`
@@ -28,6 +28,7 @@ export const query = graphql`
 
 const Home = props => {
   const limit = 2;
+  const didMountRef = useRef(false);
   const [page, setPage] = React.useState(-1);
   const [data, setData] = React.useState(props.data.prismic);
 
@@ -35,11 +36,12 @@ const Home = props => {
     return <div>no data</div>;
   }
 
-  const onPreviousClick = () => setPage(Math.max(0, page) - limit);
-  const onNextClick = () => setPage(Math.max(0, page) + limit);
+  const onPreviousClick = () => setPage(page - limit);
+  const onNextClick = () => setPage(page + limit);
 
   useEffect(() => {
-    if (page < 0) {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
       return;
     }
 
@@ -50,20 +52,28 @@ const Home = props => {
 
   return (
     <Layout>
-      <h3>List of articles</h3>
-      <ul>
-        {data.allArticles.edges.map(({ node }) => (
-          <li key={node._meta.uid}>
-            <Link to={`/article/${node._meta.uid}`}>{get(node, 'title.0.text', '---')}</Link>
-          </li>
-        ))}
-      </ul>
-      <button disabled={page <= 0} onClick={onPreviousClick}>
-        prev page
-      </button>
-      <button disabled={!data.allArticles.pageInfo.hasNextPage} onClick={onNextClick}>
-        next page
-      </button>
+      <h2>List of Articles</h2>
+      <div style={{ borderStyle: 'solid', padding: '1em', marginBottom: '1em' }}>
+        <h3>Dynamic Pagination</h3>
+        <p>
+          This example demonstrates dynamically-generated pagination. When the Next or Previous Page
+          buttons are clicked, the page query is called again to fetch metadata about the next or
+          previous pages. Notice here that pagination does not cause a URL route change.
+        </p>
+        <ul>
+          {data.allArticles.edges.map(({ node }) => (
+            <li key={node._meta.uid}>
+              <Link to={`/article/${node._meta.uid}`}>{get(node, 'title.0.text', '---')}</Link>
+            </li>
+          ))}
+        </ul>
+        <button disabled={page <= 0} onClick={onPreviousClick}>
+          prev page
+        </button>
+        <button disabled={!data.allArticles.pageInfo.hasNextPage} onClick={onNextClick}>
+          next page
+        </button>
+      </div>
     </Layout>
   );
 };

--- a/examples/pagination/src/templates/article.js
+++ b/examples/pagination/src/templates/article.js
@@ -6,7 +6,13 @@ import React from 'react';
 import Layout from '../components/layout';
 
 export const query = graphql`
-  query ArticleQuery($uid: String) {
+  query ArticleQuery(
+    $uid: String
+    $paginationPreviousUid: String!
+    $paginationPreviousLang: String!
+    $paginationNextUid: String!
+    $paginationNextLang: String!
+  ) {
     prismic {
       allArticles(uid: $uid) {
         edges {
@@ -25,13 +31,89 @@ export const query = graphql`
           }
         }
       }
+      prevArticle: article(uid: $paginationPreviousUid, lang: $paginationPreviousLang) {
+        title
+        _meta {
+          uid
+          lang
+          type
+        }
+      }
+      nextArticle: article(uid: $paginationNextUid, lang: $paginationNextLang) {
+        title
+        _meta {
+          uid
+          lang
+          type
+        }
+      }
     }
   }
 `;
 
+const Pagination = ({ nextArticle, prevArticle }) => (
+  <div style={{ borderStyle: 'solid', padding: '1em', marginBottom: '1em' }}>
+    <h3>Simple Static Pagination</h3>
+    <p>
+      This example demonstrates staticly-generated pagination without additional page queries.
+      Pagination information is retrieved directly from
+      <code>pageContext</code>.
+    </p>
+    {prevArticle ? (
+      <Link to={linkResolver(prevArticle)} aria-label="Previous Post">
+        &larr;Previous
+      </Link>
+    ) : (
+      ''
+    )}
+    {prevArticle && nextArticle && ' -- '}
+    {nextArticle ? (
+      <Link to={linkResolver(nextArticle)} aria-label="Next Post">
+        Next &rarr;
+      </Link>
+    ) : (
+      ''
+    )}
+  </div>
+);
+
+const EnhancedPagination = ({ nextArticle, prevArticle }) => (
+  <div style={{ borderStyle: 'solid', padding: '1em', marginBottom: '1em' }}>
+    <h3>Enhanced Static Pagination</h3>
+    <p>
+      This example demonstrates staticly-generated pagination enhanced with more detailed
+      information about the previous and next documents&mdash;in this case, the article title.
+      Modifying the page query is required.
+    </p>
+    {prevArticle ? (
+      <Link to={linkResolver(prevArticle._meta)} aria-label="Previous Post">
+        &larr; {RichText.asText(prevArticle.title || [], linkResolver)}
+      </Link>
+    ) : (
+      ''
+    )}
+    <div>{prevArticle && nextArticle && ' -- '}</div>
+    {nextArticle ? (
+      <Link to={linkResolver(nextArticle._meta)} aria-label="Next Post">
+        {RichText.asText(nextArticle.title || [], linkResolver)} &rarr;
+      </Link>
+    ) : (
+      ''
+    )}
+  </div>
+);
+
 const Article = props => {
+  const {
+    pageContext: { paginationPreviousMeta, paginationNextMeta },
+    data: {
+      prismic: { prevArticle, nextArticle },
+    },
+  } = props;
+
   const title = get(props.data, 'prismic.allArticles.edges.0.node.title', []);
   const slices = get(props.data, 'prismic.allArticles.edges.0.node.body', []);
+
   const body = (slices || []).map((slice, index) => (
     <React.Fragment key={index}>
       {RichText.render(get(slice, 'primary.text', []) || [], linkResolver)}
@@ -40,6 +122,8 @@ const Article = props => {
 
   return (
     <Layout>
+      <Pagination prevArticle={paginationPreviousMeta} nextArticle={paginationNextMeta} />
+      <EnhancedPagination prevArticle={prevArticle} nextArticle={nextArticle} />
       {!!title && RichText.render(title, linkResolver)}
       {body}
       <Link to="/">Back to index</Link>

--- a/examples/pagination/src/templates/article.js
+++ b/examples/pagination/src/templates/article.js
@@ -55,7 +55,7 @@ const Pagination = ({ nextArticle, prevArticle }) => (
   <div style={{ borderStyle: 'solid', padding: '1em', marginBottom: '1em' }}>
     <h3>Simple Static Pagination</h3>
     <p>
-      This example demonstrates staticly-generated pagination without additional page queries.
+      This example demonstrates statically-generated pagination without additional page queries.
       Pagination information is retrieved directly from
       <code>pageContext</code>.
     </p>
@@ -81,7 +81,7 @@ const EnhancedPagination = ({ nextArticle, prevArticle }) => (
   <div style={{ borderStyle: 'solid', padding: '1em', marginBottom: '1em' }}>
     <h3>Enhanced Static Pagination</h3>
     <p>
-      This example demonstrates staticly-generated pagination enhanced with more detailed
+      This example demonstrates statically-generated pagination enhanced with more detailed
       information about the previous and next documents&mdash;in this case, the article title.
       Modifying the page query is required.
     </p>

--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -12,6 +12,7 @@ Please **be sure your Prismic repository has the GraphQL API enabled**. It is en
 - [Getting Started](#getting-started)
 - [Usage](#usage)
   - [Automatic Page Generation](#automatic-page-generation)
+  - [Support for Multiple Languages/Locales](#support-for-multiple-languages)
   - [Page Queries: Fetch Data From Prismic](#page-queries-fetch-data-from-prismic)
   - [Prismic Previews](#prismic-previews)
   - [StaticQuery & useStaticQuery](#staticquery-and-usestaticquery)
@@ -84,7 +85,7 @@ registerLinkResolver(linkResolver);
 
 ### Automatic Page Generation
 
-You can generate pages automatically by providing mapping configuration under the `pages` option in `gatsby-config.js`.
+You can generate pages automatically by providing a mapping configuration under the `pages` option in `gatsby-config.js`.
 
 Let's assume we have the following page configuration set:
 
@@ -109,6 +110,52 @@ If you create a new unpublished blogpost, `baz` it will be accessible for previe
 - `/blogpost?uid=baz`
 
 More on [Prismic Previews](#prismic-previews) below.
+
+### Support for Multiple Languages
+
+Prismic allows you to create your content in multiple languages. This library supports that too. When setting up your configuration options in `gatsby-config.js`, there are three _optional_ properties you should be aware of: `options.defaultLang`, `options.langs`, and `options.pages[i].langs`. In the following example, all are in use:
+
+```js
+{
+  resolve: 'gatsby-source-prismic-graphql',
+  options: {
+    repositoryName: 'gatsby-source-prismic-test-site',
+    defaultLang: 'en-us',
+    langs: ['en-us', 'es-es', 'is'],
+    path: '/preview',
+    previews: true,
+    pages: [{
+      type: 'Article',
+      match: '/:lang?/:uid',
+      path: '/article',
+      component: require.resolve('./src/templates/article.js'),
+      sortBy: 'date_ASC',
+      langs: ['en-us', 'es-es', 'is'],
+    }, {
+      type: "Noticias",
+      match: '/noticias/:uid',
+      path: '/noticias',
+      component: require.resolve('./src/templates/noticias.js'),
+      sortBy: 'date_ASC',
+      langs: ['es-es'],
+    }],
+  }
+}
+```
+
+In the example above, pages are generated for two document types from Prismic--Articles and Noticias. The latter consists of news stories in Spanish. There are three languages total in use in this blog: US English, Traditional Spanish and Icelandic.
+
+For Articles, we are instructing the plugin to generate pages for articles of all three languages. But, because there is a question mark (`?`) after the `:lang` portion of the `match` property (`/:lang?/:uid`), we only include the locale tag in the URL slug for languages that are not the `defaultLang` specified above (_i.e._, 'en-us'). So for the following languages, these are the slugs generated:
+
+- US English: `/epic-destinations`
+- Spanish: `/es-es/destinos-increibles`
+- Icelandic: `/is/reykjadalur`
+
+If we had not specified a `defaultLang`, the slug for US English would have been `/en-us/epic-destinations`. And, in fact, including the `langs: ['en-us', 'es-es', 'is']` declaration for this particular document type (`Articles`) is unnecessary because we already specified that as the default language set right after `defaultLang` in the plugin options.
+
+For Noticias, however, we only want to generate pages for Spanish documents of that type (`langs` is `[es-es]`). We decide that in this context, no locale tag is needed in the URL slug; "noticias" is already enough indication that the contents are in Spanish. So we omit the `:lang` match entirely and specify only `match: '/noticias/:uid'`.
+
+This is an example of how these three properties can be used together to offer maximum flexibility. To see this in action, check out the [languages example app](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/languages).
 
 ### Page Queries: Fetch Data From Prismic
 

--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -1,38 +1,67 @@
 # gatsby-source-prismic-graphql
 
-Source data from Prismic with GraphQL
+A Gatsby plugin for fetching source data from the [Prismic headless CMS](https://prismic.io) using Prismic's beta [GraphQL API](https://prismic.io/docs/graphql/getting-started/integrate-with-existing-js-project). This plugin provides full support for Prismic's preview feature out of the box.
 
-### Differences from `gatsby-source-prismic`
+For more context, be sure to checkout Prismic's getting started guide: [Using Prismic With Gatsby](https://prismic.io/docs/reactjs/getting-started/prismic-gatsby). This README, however, serves as the most-up-to-date source of information on `gatsby-source-prismic-graphql`'s latest developments and breaking changes.
 
-This plugin will require [graphql enabled](https://prismic.io/blog/graphql-api-alpha-release) in your Prismic instance.
+Please **be sure your Prismic repository has the GraphQL API enabled**. It is enabled by default on all new Prismic repositories. If you have an older repository or are unable to access `https://[your_repo].prismic.io/graphql`, please reach out to Prismic support to request the GraphQL API.
 
-The feature is currently in _alpha_ and not recommended in production. However that being said, by using Gatsby you have the garantee of production builds to never break as they are
-statically compiled.
+## Contents
 
-## Installing
+- [Differences From gatsby-source-prismic](#differences-from-gatsby-source-prismic)
+- [Getting Started](#getting-started)
+- [Usage](#usage)
+  - [Automatic Page Generation](#automatic-page-generation)
+  - [Page Queries: Fetch Data From Prismic](#page-queries-fetch-data-from-prismic)
+  - [Prismic Previews](#prismic-previews)
+  - [StaticQuery & useStaticQuery](#staticquery-and-usestaticquery)
+  - [Fragments](#fragments)
+  - [Dynamic Queries & Fetching](#dynamic-queries-and-fetching)
+  - [Pagination](#pagination)
+  - [Working with gatsby-image](#working-with-gatsby-image)
+  - [Prismic.io A/B Experiments Integration](#prismicio-content-ab-experiments-integration)
+- [How This Plugin Works](#how-this-plugin-works)
+- [Development](#development)
+- [Issues & Troubleshooting](#issues-and-troubleshooting)
 
-Install module
+## Differences From `gatsby-source-prismic`
+
+`gatsby-source-prismic-graphql` (this plugin) fetches data using Prismic's beta [GraphQL API](https://prismic.io/docs/graphql/getting-started/integrate-with-existing-js-project) and provides full support for Prismic's Preview feature out of the box. It also provides an easy-to-configure interface for page generation.
+
+[`gatsby-source-prismic`](https://github.com/angeloashmore/gatsby-source-prismic) is a different plugin that fetches data using Prismic's REST and Javascript APIs. Previews must be coded up separately.
+
+## Getting Started
+
+**Install the plugin**
 
 ```bash
 npm install --save gatsby-source-prismic-graphql
 ```
 
-Add plugin to `gatsby-config.js`:
+or
+
+```bash
+yarn add gatsby-source-prismic-graphql
+```
+
+**Add plugin to `gatsby-config.js` and configure**
 
 ```js
 {
   resolve: 'gatsby-source-prismic-graphql',
   options: {
-    repositoryName: 'gatsby-source-prismic-test-site', // (required)
-    accessToken: '...', // (optional)
-    prismicRef: '...', // (optional, if not used then defaults to master ref. This option is useful for a/b experiments)
-    path: '/preview', // (optional, default: /preview)
-    previews: true, // (optional, default: false)
-    pages: [{ // (optional)
-      type: 'Article',         // TypeName from prismic
-      match: '/article/:uid',  // Pages will be generated under this pattern (optional)
-      path: '/article',        // Placeholder page for unpublished documents
+    repositoryName: 'gatsby-source-prismic-test-site', // required
+    defaultLang: 'en-us', // optional, but recommended
+    accessToken: '...', // optional
+    prismicRef: '...', // optional, default: master; useful for A/B experiments
+    path: '/preview', // optional, default: /preview
+    previews: true, // optional, default: false
+    pages: [{ // optional
+      type: 'Article', // TypeName from prismic
+      match: '/article/:uid', // pages will be generated under this pattern (optional)
+      path: '/article', // placeholder page for unpublished documents
       component: require.resolve('./src/templates/article.js'),
+      sortBy: 'date_ASC', // optional, default: meta_lastPublicationDate_ASC; useful for pagination
     }],
     sharpKeys: [
       /image|photo|picture/, // (default)
@@ -42,7 +71,7 @@ Add plugin to `gatsby-config.js`:
 }
 ```
 
-Edit your `gatsby-browser.js`:
+**Edit your `gatsby-browser.js`**
 
 ```js
 const { registerLinkResolver } = require('gatsby-source-prismic-graphql');
@@ -53,9 +82,37 @@ registerLinkResolver(linkResolver);
 
 ## Usage
 
-### Fetch data from Prismic
+### Automatic Page Generation
 
-It is very easy to fetch data from prismic.
+You can generate pages automatically by providing mapping configuration under the `pages` option in `gatsby-config.js`.
+
+Let's assume we have the following page configuration set:
+
+```js
+{
+  pages: [{
+    type: 'Article',
+    match: '/blogpost/:uid',
+    path: '/blogpost',
+    component: require.resolve('./src/templates/article.js'),
+  }],
+}
+```
+
+If you have two blog posts with UIDs of `foo` and `bar`, the following URL slugs will be generated:
+
+- `/blogpost/foo`
+- `/blogpost/bar`
+
+If you create a new unpublished blogpost, `baz` it will be accessible for preview under, assuming you've established a preview session with Prismic:
+
+- `/blogpost?uid=baz`
+
+More on [Prismic Previews](#prismic-previews) below.
+
+### Page Queries: Fetch Data From Prismic
+
+It is very easy to fetch data from Prismic in your pages:
 
 ```jsx
 import React from 'react';
@@ -80,39 +137,19 @@ export default function Page({ data }) => <>
 
 ### Prismic Previews
 
-Previews are enabled by default.
+Previews are enabled by default, however they must be configured in your prismic instance/repository. For instructions on configuring previews in Prismic, refer to Prismic's guide: [How to set up a preview](https://user-guides.prismic.io/preview/how-to-set-up-a-preview/how-to-set-up-a-preview).
 
-[Read how to enable previews](https://user-guides.prismic.io/preview/how-to-set-up-a-preview/how-to-set-up-a-preview) in your prismic instance.
+When testing previews, be sure you are starting from a valid Prismic preview URL/path. The most reliable way to test previews is by using the preview button from your draft in Prismic. If you wish to test the Preview locally, catch the URL that opens immediately after clicking the preview link:
 
-### Generated pages
+`https://[your-domain.tld]/preview?token=https%3A%2F%[your-prismic-repo].prismic.io%2Fpreviews%2FXRag6xAAACA...ABwjduaa%3FwebsitePreviewId%3DXRA...djaa&documentId=XRBH...jduAa`
 
-You can generate pages automatically by providing mapping configuration under the `pages` option.
+Then replace the protocol and domain at the beginning of the URL with your `localhost:PORT` instance, or wherever you're wanting to preview from.
 
-If you have two blog posts like `foo`, `bar`, it will generate the following URLs:
+This URL will be parsed and replaced by the web app and browser with the proper URL as specified in your page configuration.
 
-- /blogpost/foo
-- /blogpost/bar
+### StaticQuery and useStaticQuery
 
-If you create a new unpublished blogpost, `baz` it will be accessible for preview under:
-
-- /blogpost?uid=baz
-
-[See the example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/default)
-
-```js
-{
-  pages: [{
-    type: 'Article',
-    match: '/blogpost/:uid',
-    path: '/blogpost',
-    component: require.resolve('./src/templates/article.js'),
-  }],
-}
-```
-
-### StaticQuery
-
-You can use static queries like normal, but if you would like to preview them, use the `withPreview` function.
+You can use `StaticQuery` as usual, but if you would like to preview them, you must use the `withPreview` function.
 
 [See the example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/static-query)
 
@@ -136,9 +173,7 @@ export const Articles = () => (
 );
 ```
 
-### useStaticQuery
-
-No support yet.
+`useStaticQuery` is not yet supported.
 
 ### Fragments
 
@@ -146,7 +181,7 @@ Fragments are supported for both page queries and static queries.
 
 [See the example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/fragments)
 
-**Page components**:
+**Within page components**:
 
 ```jsx
 import { graphql } from 'gatsby';
@@ -165,7 +200,7 @@ MyPage.fragments = [fragmentX];
 export default MyPage;
 ```
 
-**StaticQuery**:
+**With StaticQuery**:
 
 ```jsx
 import { StaticQuery, graphql } from 'gatsby';
@@ -188,11 +223,9 @@ export default () => (
 
 ```
 
-### Pagination and other dynamic fetching
+### Dynamic Queries and Fetching
 
-You can use this plugin to dynamically fetch different component for your component. This is great for cases like pagination. See the following example:
-
-[See the example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/pagination)
+You can use this plugin to dynamically fetch data for your component using `prismic.load`. Refer to the [pagination example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/pagination) to see it in action.
 
 ```jsx
 import React from 'react';
@@ -215,7 +248,7 @@ export const query = graphql`
 export default function Example({ data, prismic }) {
   const handleClick = () =>
     prismic.load({
-      variables: { limit: 100 },
+      variables: { limit: 20 },
       query, // (optional)
       fragments: [], // (optional)
     });
@@ -227,11 +260,38 @@ export default function Example({ data, prismic }) {
 }
 ```
 
+### Pagination
+
+Pagination can be accomplished statically (_i.e._, during initialy page generation) or dynamically (_i.e._, with JS in the browser). Examples of both can be found in the [pagination example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/pagination).
+
+Prismic pagination is cursor-based. See Prismic's [Paginate your results](https://prismic.io/docs/graphql/query-the-api/paginate-your-results) article to learn about cursor-based pagination.
+
+By default, pagination will be sorted by last publication date. If you would like to change that, specify a `sortBy` value in your page configuration in `gatsby-config.js`.
+
+#### Dynamically-Generated Pagination
+
+When coupled with `prismic.load`, as demonstrated in the [index page of the pagination example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/pagination), other pages can be fetched dynamically using page and cursor calculations.
+
+GraphQL documents from Prismic have a cursor--a base64-encoded string that represents their order, or page number, in the set of all documents queried. We provide two helpers for converting between cursor strings and page numbers:
+
+- `getCursorFromDocumentIndex(index: number)`
+- `getDocumentIndexFromCursor(cursor: string)`
+
+#### Statically-Generated Pagination
+
+##### Basic Pagination
+
+For basic linking between the pages, metadata for the previous and next pages are provided to you automatically via `pageContext` in the `paginationPreviousMeta` and `paginationNextMeta` properties. These can be used in conjunction with your `linkResolver` to generate links between pages without any additional GraphQL query. For an example of this, take a look at the `<Pagination />` component in the pagination example's [`article.js`](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/pagination/src/templates/article.js).
+
+##### Enhanced Pagination
+
+If you would like to gather other information about previous and next pages (say a title or image), simply modify your page query to retrieve those documents. This also is demonstrated in the same [pagination example](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/pagination/src/templates/article.js) with the `<EnhancedPagination />` component and the page's GraphQL query.
+
 ### Working with gatsby-image
 
-Latest version of the plugin supports gatsby-image by adding a new property to graphql types that contain fields that match the `sharpKeys` array (this defaults to `/image|photo|picture/`) with the `Sharp` suffix.
+The latest versions of this plugin support gatsby-image by adding a new property to GraphQL types that contains fields that match the `sharpKeys` array (this defaults to `/image|photo|picture/`) to the `Sharp` suffix.
 
-**Note:** When querying, make sure to also query the source field, eg.
+**Note:** When querying, make sure to also query the source field. For example:
 
 ```gql
 query {
@@ -271,7 +331,7 @@ query {
 }
 ```
 
-**NOTE** Does not transform images in preview mode, so make sure to fallback to the default image when the sharp image is null.
+**NOTE** Images are not transformed in preview mode, so be sure to fall back to the default image when the sharp image is `null`.
 
 ```tsx
 import Img from 'gatsby-image';
@@ -287,24 +347,20 @@ return sharpImage ? (
 );
 ```
 
-Later we may add a Image component that does this for you, and leverages the new Prismic Image API as fallback for preview modes.
+Later, we may add an `Image` component that does this for you and leverages the new Prismic Image API as a fallback for preview modes.
 
-### Prismic.io content a/b experiments integration
+### Prismic.io Content A/B Experiments Integration
 
-You can use this plugin in combination with Prismic's built-in experiments functionality, and a hosting service like Netlify, to run content a/b tests.
+You can use this plugin in combination with Prismic's built-in experiments functionality, and a hosting service like Netlify, to run content A/B tests.
 
-Experiments in Prismic are basically branches of the core content, split into 'refs' similar to git branches.
-So if you want to get content from a certain experiment variation, you can pass the corresponding ref through to Prismic in your request,
-and it will return content based on that ref's variation.
+Experiments in Prismic are basically branches of the core content, split into 'refs' similar to git branches. So if you want to get content from a certain experiment variation, you can pass the corresponding ref through to Prismic in your request, and it will return content based on that ref's variation.
 
-A/B experiments are tricky to implement in a static website though; a/b testing needs a way to dynamically serve up the different variations
-to different website visitors. This is at odds with the idea of a static, non-dynamic website.
+A/B experiments are tricky to implement in a static website though; A/B testing needs a way to dynamically serve up the different variations to different website visitors. This is at odds with the idea of a static, non-dynamic website.
 
-Fortunately, static hosting providers like Netlify allow you to run a/b tests at a routing level.
-This makes it possible for us to build multiple versions of our project using different source data, and then within Netlify
+Fortunately, static hosting providers like Netlify allow you to run A/B tests at a routing level. This makes it possible for us to build multiple versions of our project using different source data, and then within Netlify
 split traffic to our different static variations.
 
-Therefore, we can use a/b experiments from Prismic in the following way:
+Therefore, we can use A/B experiments from Prismic in the following way:
 
 1. Setup an experiment in Prismic.
 
@@ -318,7 +374,7 @@ Therefore, we can use a/b experiments from Prismic in the following way:
 
 6. Now your static website will show different experimental variations of the content to different users! At this point the process is manual and non-ideal, but hopefully we'll be able to automate it more in the future.
 
-## How this plugin works
+## How This Plugin Works
 
 1. The plugin creates a new page at `/preview` (by default, you can change this), that will be your preview URL you setup in the Prismic admin interface.
 
@@ -326,11 +382,11 @@ Therefore, we can use a/b experiments from Prismic in the following way:
 
 2. It uses a different `babel-plugin-remove-graphql-queries` on the client.
 
-   The modified plugin emits your graphql queries as string so they can be read and re-used on the client side by the plugin.
+   The modified plugin emits your GraphQL queries as a string so they can be read and re-used on the client side by the plugin.
 
 3. Once redirected to a page with the content, everything will load normally.
 
-   In the background, the plugin takes your original gatsby graphql query, extracts the prismic subquery and uses it to make a graphql request to Prismic with a preview reference.
+   In the background, the plugin takes your original Gatsby GraphQL query, extracts the Prismic subquery and uses it to make a GraphQL request to Prismic with a preview reference.
 
    Once data is received, it will update the `data` prop with merged data from Prismic preview and re-render the component.
 
@@ -350,11 +406,9 @@ yarn start
 
 ## Issues and Troubleshooting
 
-This plugin does not have gatsby-plugin-sharp support.
-
 Please raise an issue on GitHub if you have any problems.
 
-### My page graphql query does not hot-reload for previews
+### My page GraphQL query does not hot-reload for previews
 
 This is a Gatsby limitation. You can bypass this limitation by adding the following:
 

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -55,6 +55,7 @@ const getPagesQuery = ({ pageType }: { pageType: string }) => `
               id
               lang
               uid
+              type
               alternateLanguages {
                 id
                 lang
@@ -161,6 +162,8 @@ function createPagesFromEdges(
         ...node._meta,
         cursor,
         // would it be better to also include cursor or uid for prev and next pages?
+        prevPageMeta: edges[index - 1] ? edges[index - 1].node._meta : null,
+        nextPageMeta: edges[index + 1] ? edges[index + 1].node._meta : null,
         // lastPageEndCursor: index === 0 ? lastEndCursor : endCursor, // for paging back
         lastPageEndCursor: edges[index - 1] ? edges[index - 1].endCursor : '',
       },

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -51,7 +51,16 @@ function createDocumentPreviewPage(createPage: Function, page: Page, lang?: stri
     path: page.path,
     matchPath: process.env.NODE_ENV === 'production' ? undefined : page.match,
     component: page.component,
-    context: { rootQuery, id: '', uid: '', lang },
+    context: {
+      rootQuery,
+      id: '',
+      uid: '',
+      lang,
+      paginationPreviousUid: '',
+      paginationPreviousLang: '',
+      paginationNextUid: '',
+      paginationNextLang: '',
+    },
   });
 }
 
@@ -91,6 +100,9 @@ function createDocumentPages(
 ): void {
   // Cycle through each document returned from query...
   edges.forEach(({ cursor, node }: any, index: number) => {
+    const previousNode = edges[index - 1] && edges[index - 1].node;
+    const nextNode = edges[index + 1] && edges[index + 1].node;
+
     // ...and create the page
     createPage({
       path: createDocumentPath(page, node, options.defaultLang),
@@ -99,9 +111,14 @@ function createDocumentPages(
         rootQuery: getRootQuery(page.component),
         ...node._meta,
         cursor,
-        prevPageMeta: edges[index - 1] ? edges[index - 1].node._meta : null,
-        nextPageMeta: edges[index + 1] ? edges[index + 1].node._meta : null,
-        lastPageEndCursor: edges[index - 1] ? edges[index - 1].endCursor : '',
+        paginationPreviousMeta: previousNode ? previousNode._meta : null,
+        paginationPreviousUid: previousNode ? previousNode._meta.uid : '',
+        paginationPreviousLang: previousNode ? previousNode._meta.lang : '',
+        paginationNextMeta: nextNode ? nextNode._meta : null,
+        paginationNextUid: nextNode ? nextNode._meta.uid : '',
+        paginationNextLang: nextNode ? nextNode._meta.lang : '',
+        // pagination helpers for overcoming backwards pagination issues cause by Prismic's 20-document query limit
+        lastQueryChunkEndCursor: edges[index - 1] ? edges[index - 1].endCursor : '',
       },
     });
   });

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -34,7 +34,7 @@ exports.sourceNodes = (ref: any, options: PluginOptions) => {
   return sourceNodes(ref, opts);
 };
 
-const getPagesQuery = ({ pageType }: { pageType: string }) => `
+const getPagesQuery = ({ pageType, page }: { pageType: string; page: any }) => `
   query AllPagesQuery (
     $after: String
   ) {
@@ -42,6 +42,7 @@ const getPagesQuery = ({ pageType }: { pageType: string }) => `
       ${pageType} (
         first: 20
         after: $after
+        sortBy: ${page.sortBy || 'meta_lastPublicationDate_ASC'}
       ) {
         totalCount
         pageInfo {
@@ -88,7 +89,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
   // (Prismic GraphQL queries only return up to 20 results per query)
   async function createPageRecursively(page: any, endCursor: string = '') {
     const pageType = `all${page.type}s`;
-    const query = getPagesQuery({ pageType });
+    const query = getPagesQuery({ pageType, page });
     const { data, errors } = await graphql(query, { after: endCursor });
     const rootQuery = getRootQuery(page.component);
 

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -35,7 +35,7 @@ exports.sourceNodes = (ref: any, options: PluginOptions) => {
 };
 
 function createGeneralPreviewPage(createPage: Function, options: PluginOptions): void {
-  const previewPath = options.previewPath || '/preview';
+  const previewPath: string = options.previewPath || '/preview';
   createPage({
     path: previewPath.replace(/^\//, ''),
     component: path.resolve(path.join(__dirname, 'components', 'PreviewPage.js')),
@@ -67,19 +67,19 @@ function createDocumentPreviewPage(createPage: Function, page: Page, lang?: stri
  */
 function createDocumentPath(pageOptions: Page, node: any, defaultLang?: string): string {
   const pathKeys: any[] = [];
-  const pathTemplate = pageOptions.match || pageOptions.path;
+  const pathTemplate: string = pageOptions.match || pageOptions.path;
   pathToRegexp(pathTemplate, pathKeys);
   const langKey = pathKeys.find(key => key.name === 'lang');
-  const isLangOptional = !!(langKey && langKey.optional);
-  const toPath = pathToRegexp.compile(pathTemplate);
+  const isLangOptional: boolean = !!(langKey && langKey.optional);
+  const toPath: Function = pathToRegexp.compile(pathTemplate);
 
-  const documentLang = node._meta.lang;
-  const isDocumentLangDefault = documentLang === defaultLang;
-  const shouldExcludeLangInPath = isLangOptional && isDocumentLangDefault;
-  const lang = shouldExcludeLangInPath ? null : documentLang;
+  const documentLang: string = node._meta.lang;
+  const isDocumentLangDefault: boolean = documentLang === defaultLang;
+  const shouldExcludeLangInPath: boolean = isLangOptional && isDocumentLangDefault;
+  const lang: string | null = shouldExcludeLangInPath ? null : documentLang;
 
   const params = { ...node._meta, lang };
-  const path = toPath(params);
+  const path: string = toPath(params);
   return path === '' ? '/' : path;
 }
 
@@ -163,10 +163,10 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     endCursor: string = '',
     documents: [any?] = []
   ): Promise<any> {
-    const documentType = `all${page.type}s`;
-    const sortType = `PRISMIC_Sort${page.type}y`;
-    const query = getDocumentsQuery({ documentType, sortType });
-
+    // Prepare and execute query
+    const documentType: string = `all${page.type}s`;
+    const sortType: string = `PRISMIC_Sort${page.type}y`;
+    const query: string = getDocumentsQuery({ documentType, sortType });
     const { data, errors } = await graphql(query, {
       after: endCursor,
       lang: lang || null,
@@ -186,7 +186,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     documents = [...documents, ...response.edges] as [any?];
 
     if (response.pageInfo.hasNextPage) {
-      const newEndCursor = response.pageInfo.endCursor;
+      const newEndCursor: string = response.pageInfo.endCursor;
       await createPagesForType(page, lang, newEndCursor, documents);
     } else {
       createDocumentPreviewPage(createPage, page, lang);
@@ -194,9 +194,11 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     }
   }
 
-  // Create all the pages!
-  const pages = options.pages || [];
+  // Prepare to create all the pages
+  const pages: Page[] = options.pages || [];
   const pageCreators: Promise<any>[] = [];
+
+  // Create pageCreator promises for each page/language combination
   pages.forEach(
     (page: Page): void => {
       const langs = page.langs || options.langs || (options.defaultLang && [options.defaultLang]);
@@ -208,6 +210,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     }
   );
 
+  // Run all pageCreators simultaneously
   await Promise.all(pageCreators);
 };
 

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -45,17 +45,13 @@ function createGeneralPreviewPage(createPage: Function, options: PluginOptions):
   });
 }
 
-function createDocumentPreviewPage(createPage: Function, options: PluginOptions, page: Page): void {
+function createDocumentPreviewPage(createPage: Function, page: Page, lang?: string): void {
+  const rootQuery = getRootQuery(page.component);
   createPage({
     path: page.path,
     matchPath: process.env.NODE_ENV === 'production' ? undefined : page.match,
     component: page.component,
-    context: {
-      rootQuery: getRootQuery(page.component),
-      id: '',
-      uid: '',
-      lang: options.defaultLang,
-    },
+    context: { rootQuery, id: '', uid: '', lang },
   });
 }
 
@@ -186,7 +182,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
       const newEndCursor = response.pageInfo.endCursor;
       await createPagesForType(page, lang, newEndCursor, documents);
     } else {
-      createDocumentPreviewPage(createPage, options, page);
+      createDocumentPreviewPage(createPage, page, lang);
       createDocumentPages(createPage, documents, options, page);
     }
   }

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -107,8 +107,14 @@ function createDocumentPages(
   });
 }
 
-const getDocumentsQuery = ({ documentType }: { documentType: string }): string => `
-  query AllPagesQuery ($after: String, $lang: String, $sortBy: PRISMIC_SortPosty) {
+const getDocumentsQuery = ({
+  documentType,
+  sortType,
+}: {
+  documentType: string;
+  sortType: string;
+}): string => `
+  query AllPagesQuery ($after: String, $lang: String, $sortBy: ${sortType}) {
     prismic {
       ${documentType} (
         first: 20
@@ -158,7 +164,8 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     documents: [any?] = []
   ): Promise<any> {
     const documentType = `all${page.type}s`;
-    const query = getDocumentsQuery({ documentType });
+    const sortType = `PRISMIC_Sort${page.type}y`;
+    const query = getDocumentsQuery({ documentType, sortType });
 
     const { data, errors } = await graphql(query, {
       after: endCursor,
@@ -189,9 +196,6 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
 
   // Create all the pages!
   const pages = options.pages || [];
-
-  // TODO: Decide whether options.defaultLang should be required. If not, what does it default to?
-  // allQueries accept `null` as the lang. Post does not.
   const pageCreators: Promise<any>[] = [];
   pages.forEach(
     (page: Page): void => {

--- a/packages/gatsby-source-prismic-graphql/src/index.ts
+++ b/packages/gatsby-source-prismic-graphql/src/index.ts
@@ -4,6 +4,8 @@ export { withPreview } from './components/withPreview';
 export {
   PrismicLink,
   getCookies,
+  getCursorFromDocumentIndex,
+  getDocumentIndexFromCursor,
   registerLinkResolver,
   linkResolver,
   fieldName,

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -3,7 +3,7 @@ interface Page {
   match: string;
   path: string;
   component: string;
-  lang?: string;
+  langs?: string[];
   sortBy?: string;
 }
 
@@ -13,6 +13,7 @@ export interface PluginOptions {
   prismicRef?: null | string;
   linkResolver?: Function;
   defaultLang?: string;
+  langs?: string[];
   passContextKeys?: string[];
   previewPath?: string;
   previews?: boolean;

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -4,6 +4,7 @@ interface Page {
   path: string;
   component: string;
   lang?: string;
+  sortBy?: string;
 }
 
 export interface PluginOptions {

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -1,4 +1,4 @@
-interface Page {
+export interface Page {
   type: string;
   match: string;
   path: string;

--- a/packages/gatsby-source-prismic-graphql/src/utils/index.ts
+++ b/packages/gatsby-source-prismic-graphql/src/utils/index.ts
@@ -27,6 +27,14 @@ export function getCookies() {
   return parseQueryString(document.cookie, ';');
 }
 
+export function getDocumentIndexFromCursor(cursor: string) {
+  return atob(cursor).split(':')[1];
+}
+
+export function getCursorFromDocumentIndex(index: number) {
+  return btoa(`arrayconnection:${index}`);
+}
+
 export function fetchStripQueryWhitespace(url: string, ...args: any) {
   const [hostname, qs = ''] = url.split('?');
   const queryString = parseQueryString(qs);


### PR DESCRIPTION
This PR fixes several things around pagination. But in order to fix pagination, **there are breaking changes** around how languages are specified in the plugin and page configuration.

The README has been updated accordingly and organized with a Table of Contents. Links out to examples will work once merged. I highly recommend reading the README closely as part of the review process for this PR.

## Current State of the  Dynamic Pagination Example
The pagination example in this repo demonstrates dynamically-generated pagination. That approach has pros an cons. One con is that it doesn’t leverage Gatsby’s greatest strength—that of static page generation.

The example also had a nasty bug where pagination got out of sync when paging forward and then backward. This PR fixes that.

Another bug arises in multi-locale/language environments. This library allows for the specification of one language per page entry. During page creation in `gatsby-node.ts`, if the language of the fetched document doesn’t match up with the one specified in the Page entry, `gatsby-node.ts` simply skips creating a page for that page. But the cursor is still there and assumes the page exists! This means that even the dynamic pagination examples in this library will be broken when employed in multi-language sites. The previous or next cursor, if the page belonging to it is not the right language, will try to take the user to a page that was never generated!

Furthermore, pagination follows the default order of document creation in `gatsby-node.ts`. When not specified, this is `meta_lastPublicationDate_ASC`. Most people will probably want pagination to follow their own sort of the documents. For example, I’m working on a revamp of my wife’s photography website. We will be migrating all of our old content to Prismic…much of it manually, for various reasons. We don’t want blogs to be ordered according to when we post them in Prismic. We want them ordered by a custom date field. That’s not possible with this library currently.

This PR fixes both bugs and introduces a **new, optional, `sortBy` page configuration option**. 

Note, however, that the fix introduced for the multi-language issue introduces a breaking change. In page options, languages are now specified with an optional `langs: string[]`, not a `lang: string`. 

## Introducing Static Pagination
Static pagination is a big challenge when using the Prismic GraphQL endpoint due to it’s 20-document limit. Pagination forward is no problem at all. You can ask for document(s) after the cursor. But pagination backwards is problematic.

As Raul from Prismic support put it:

> It definitely feels like unintended behavior, but not really a bug. A GraphQL query with ‘before’ is less “get the 20 results that precede this cursor” and more “get all results until you hit cursor” and paginates however many there are. Not sure if there’s a way to make it behave in the more intuitive manner, but we will explore this issue.

Pages must be queried in 20-document chunks. If you are on page 25 and ask Prismic for the `last: 1` page `before: currentCursor`, you’ll get page `19`, not page `24`, as hoped.

In the dynamic example, this can easily be overcome by converting the base64 cursor into a page number, doing some math, and converting back to base64 to get the cursors you want for performing another query. But to enable statically-generated pagination, the proper cursors must be provided to the page context from `gatsby-node.ts` at compile time.

This PR does just that. Statically-generated pagination is now possible, and simple and more advanced static pagination examples are added to the pagination example app.

This PR also fixes some issues around previews for multiple languages. Previews now work consistently regardless of language.

## Other Modifications/Improvements

Finally, this PR also:
* turns the base64 cursor encoding/decoding into helper functions for convenient use,
* updates the README, adding more context, informing about new features and pagination, and adding a table of contents for easier navigation
* refactors `gatsby-node.ts` for added clarity

## Possible Future Work
* option to specify a `documentsPerPage` in the page config
* option to specify a query filter in the page config
* specify a function instead of a regex string for page slug generation
* we’re going to need unit tests soon too!