### PR TITLE
fix: check if proptypes can be added to StaticQuery

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-browser.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-browser.tsx
@@ -4,13 +4,15 @@ import React from 'react';
 import { WrapPage } from './components/WrapPage';
 
 // Fixes proptypes warning for StaticQuery
-(StaticQuery as any).propTypes.query = PropTypes.oneOfType([
-  PropTypes.string,
-  PropTypes.shape({
-    id: PropTypes.string,
-    source: PropTypes.string,
-  }),
-]);
+if (StaticQuery && typeof StaticQuery === 'object' && (StaticQuery as any).propTypes) {
+  (StaticQuery as any).propTypes.query = PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      id: PropTypes.string,
+      source: PropTypes.string,
+    }),
+  ]);
+}
 
 interface WrapPageArgs {
   element: any;


### PR DESCRIPTION
Fixes an issue on Gatsby builds where propTypes are attempted to be added to `StaticQuery` while `StaticQuery` is a function, resulting in an uncaught TypeError.