### PR TITLE
Fix bug on removing sharp Images from Preview

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*"],
-  "version": "3.4.0-beta.2",
+  "version": "3.4.0-beta.3",
   "command": {
     "publish": {
       "conventionalCommits": true

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*"],
-  "version": "3.4.0-beta.1",
+  "version": "3.4.0-beta.2",
   "command": {
     "publish": {
       "conventionalCommits": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "gatsby-source-prismic-graphql",
-  "version": "3.4.0-beta.2",
+  "version": "3.4.0-beta.3",
   "workspaces": {
     "packages": [
       "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "gatsby-source-prismic-graphql",
-  "version": "3.4.0-beta.2"
+  "version": "3.4.0-beta.2",
   "workspaces": {
     "packages": [
       "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "private": true,
-  "name": "root",
+  "private": false,
+  "name": "gatsby-source-prismic-graphql",
+  "version": "3.4.0-beta.2"
   "workspaces": {
     "packages": [
       "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "private": false,
-  "name": "gatsby-source-prismic-graphql",
+  "private": true,
+  "name": "root",
   "version": "3.4.0-beta.2",
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "root",
+  "name": "gatsby-source-prismic-graphql",
   "version": "3.4.0-beta.2",
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "gatsby-source-prismic-graphql",
+  "name": "@lalmachado/gatsby-source-prismic-graphql",
   "version": "3.4.0-beta.3",
   "workspaces": {
     "packages": [

--- a/packages/gatsby-source-prismic-graphql/package.json
+++ b/packages/gatsby-source-prismic-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "private": false,
-  "name": "gatsby-source-prismic-graphql",
+  "name": "@lalmachado/gatsby-source-prismic-graphql",
   "description": "Source data from Prismic with GraphQL",
   "license": "MIT",
   "author": "Birkir Gudjonsson <birkir.gudjonsson@gmail.com>",
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/birkir/gatsby-source-prismic-graphql/issues"
   },
-  "version": "3.4.0-beta.1",
+  "version": "3.4.0-beta.3",
   "main": "index.js",
   "files": [
     "*.js",

--- a/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
@@ -27,7 +27,7 @@ const stripSharp = (query: any) => {
       this.parent.node.kind === 'Field' &&
       x.value.match(/Sharp$/)
     ) {
-      this.parent.remove();
+      this.parent.delete();
     }
   });
 };


### PR DESCRIPTION
as indicated here https://github.com/substack/js-traverse/issues/48 traverse remove func was preventing  stripSharp from removing all sharp images references from the query, using traverse delete resolves the problem