### PR TITLE
fix: unescape createRemoteFileNode url

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -5,6 +5,7 @@ import { fieldName, PrismicLink, typeName } from './utils';
 import { Page, PluginOptions } from './interfaces/PluginOptions';
 import { createRemoteFileNode } from 'gatsby-source-filesystem';
 import pathToRegexp from 'path-to-regexp';
+import querystring from 'querystring';
 
 exports.onCreateWebpackConfig = onCreateWebpackConfig;
 
@@ -264,7 +265,7 @@ exports.createResolvers = (
             const url = args.crop ? obj[args.crop] && obj[args.crop].url : obj.url;
             if (url) {
               return createRemoteFileNode({
-                url,
+                url: querystring.unescape(url),
                 store,
                 cache,
                 createNode,


### PR DESCRIPTION
Prismic returns "percent-encoding" image urls, files were saved by Gatsby but could not be used.

### Example
Before the fix:
```
"image": {
  "url": "https://.../repo-name%2F3ccbf3d2-e178-4ad5-be80-52fb5324c220_mission-headline.svg"
},
"imageSharp": {
  "publicURL": "/static/repo-name%2F3ccbf3d2-e178-4ad5-be80-52fb5324c220_mission-headline.svg"
}
```

With the fix:
```
"image": {
  "url": "https://.../repo-name%2F3ccbf3d2-e178-4ad5-be80-52fb5324c220_mission-headline.svg"
},
"imageSharp": {
  "publicURL": "/static/3ccbf3d2-e178-4ad5-be80-52fb5324c220_mission-headline-231ee29b25c7112da6767fe575dcc09e.svg"
}
```