### PR TITLE
feat: Add optional filter to page generation

### DIFF
--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -111,6 +111,36 @@ If you create a new unpublished blogpost, `baz` it will be accessible for previe
 
 More on [Prismic Previews](#prismic-previews) below.
 
+#### Conditionally generating pages
+
+If the default page generation doesn't cover your use-case, you can provide an optional `filter` option to your individual page configurations.
+
+For example, if you had a single Prismic _Article_ type and wanted pages with `music` in their UIDs to be generated at a different URL :
+
+```js
+{
+  pages: [{
+    type: 'Article',
+    match: '/musicblog/:uid',
+    filter: data => data.node._meta.uid.includes('music'),
+    path: '/blogposts',
+    component: require.resolve('./src/templates/article.js'),
+  }, {
+    type: 'Article',
+    match: '/blog/:uid',
+    filter: data => !data.node._meta.uid.includes('music'),
+    path: '/blogposts',
+    component: require.resolve('./src/templates/article.js'),
+  }],
+}
+```
+
+Given 3 articles with UIDs of `why-i-like-music`, `why-i-like-sports` and `why-i-like-food`, the following URL slugs will be generated:
+
+- `/musicblog/why-i-like-music`
+- `/blog/why-i-like-sports`
+- `/blog/why-i-like-food`
+
 ### Support for Multiple Languages
 
 Prismic allows you to create your content in multiple languages. This library supports that too. When setting up your configuration options in `gatsby-config.js`, there are three _optional_ properties you should be aware of: `options.defaultLang`, `options.langs`, and `options.pages[i].langs`. In the following example, all are in use:

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -195,12 +195,13 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     }
 
     const response = data.prismic[documentType];
+    const edges = page.filter ? response.edges.filter(page.filter) : response.edges;
 
     // Add last end cursor to all edges to enable pagination context when creating pages
-    response.edges.forEach((edge: any) => (edge.endCursor = endCursor));
+    edges.forEach((edge: any) => (edge.endCursor = endCursor));
 
     // Stage documents for page creation
-    documents = [...documents, ...response.edges] as [any?];
+    documents = [...documents, ...edges] as [any?];
 
     if (response.pageInfo.hasNextPage) {
       const newEndCursor: string = response.pageInfo.endCursor;

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -5,6 +5,7 @@ export interface Page {
   component: string;
   langs?: string[];
   sortBy?: string;
+  filter?: Function;
 }
 
 export interface PluginOptions {


### PR DESCRIPTION
This PR allows users to apply a filter to their Prismic documents before generating pages (rather than generating them for *all* documents). This is useful in cases where a single custom type is used to manage slices in Prismic, yet the resulting pages need to have different URL patterns.

For example, my company has a single Page type that contains all page slices. Our homepages need to be available at `/:lang?/`, while all other pages are `/:lang?/:uid`. Since all of our homepage slugs are `home-${lang}`, I can now simply filter out all Page documents with a UID starting with `home-` as follows :

```js
{
    pages: [
        {
            type: 'Page',
            match: '/:lang?/',
            path: '/pages',
            component: require.resolve('./src/templates/Page.tsx'),
            filter: ({ node }) => node._meta.uid.startsWith('home-'),
        },
        {
            type: 'Page',
            match: '/:lang?/:uid',
            path: '/pages',
            component: require.resolve('./src/templates/Page.tsx'),
            filter: ({ node }) => !node._meta.uid.startsWith('home-'),
        }
    ],
}
```