### PR TITLE
feat: support short language codes in generated paths

### DIFF
--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -157,6 +157,12 @@ For Noticias, however, we only want to generate pages for Spanish documents of t
 
 This is an example of how these three properties can be used together to offer maximum flexibility. To see this in action, check out the [languages example app](https://github.com/birkir/gatsby-source-prismic-graphql/tree/master/examples/languages).
 
+#### (Optional) Short language codes
+
+To use short language codes (_e.g. `/fr/articles`_) instead of the default (_e.g. `/fr-fr/articles`_), you can set `options.shortenUrlLangs` to `true`.
+
+Keep in mind that if you use this option & have multiple variants of a language (e.g. _en-us_ and _en-au_) that would be shortened to the same value, you should add UIDs to your URLs to differentiate them.
+
 ### Page Queries: Fetch Data From Prismic
 
 It is very easy to fetch data from Prismic in your pages:

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -69,12 +69,18 @@ function createDocumentPreviewPage(createPage: Function, page: Page, lang?: stri
  * @param pageOptions - Returned paths are based on the `match` or `path` (if `match`
  * is not present) properties of the `pageOptions` object.
  * @param node - Document node metadata provide the `lang` and `uid` values for the returned path.
- * @param defaultLang - `defaultLang` as declared in `PluginOptions`. If `lang` segment is
+ * @param options - The plugin's global options.
+ * @param options.defaultLang - `defaultLang` as declared in `PluginOptions`. If `lang` segment is
  * marked optional (`:lang?`) in the page `match` or `path` values and `defaultLang` matches the
  * document's actual language, the language segment of the path will be omitted in the returned path.
+ * @param options.shortenUrlLangs - When truthy, the lang used for the path will be limited to 2 characters.
  * @return The path for the document's URL with `lang` and `uid` interpolated as necessary.
  */
-function createDocumentPath(pageOptions: Page, node: any, defaultLang?: string): string {
+function createDocumentPath(
+  pageOptions: Page,
+  node: any,
+  { defaultLang, shortenUrlLangs }: PluginOptions
+): string {
   const pathKeys: any[] = [];
   const pathTemplate: string = pageOptions.match || pageOptions.path;
   pathToRegexp(pathTemplate, pathKeys);
@@ -85,7 +91,8 @@ function createDocumentPath(pageOptions: Page, node: any, defaultLang?: string):
   const documentLang: string = node._meta.lang;
   const isDocumentLangDefault: boolean = documentLang === defaultLang;
   const shouldExcludeLangInPath: boolean = isLangOptional && isDocumentLangDefault;
-  const lang: string | null = shouldExcludeLangInPath ? null : documentLang;
+  const displayedLang: string = shortenUrlLangs ? documentLang.slice(0, 2) : documentLang;
+  const lang: string | null = shouldExcludeLangInPath ? null : displayedLang;
 
   const params = { ...node._meta, lang };
   const path: string = toPath(params);
@@ -105,7 +112,7 @@ function createDocumentPages(
 
     // ...and create the page
     createPage({
-      path: createDocumentPath(page, node, options.defaultLang),
+      path: createDocumentPath(page, node, options),
       component: page.component,
       context: {
         rootQuery: getRootQuery(page.component),

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -14,6 +14,7 @@ export interface PluginOptions {
   linkResolver?: Function;
   defaultLang?: string;
   langs?: string[];
+  shortenUrlLangs?: boolean;
   passContextKeys?: string[];
   previewPath?: string;
   previews?: boolean;


### PR DESCRIPTION
Adds the option of generating paths using short language code (_e.g. `/fr/articles`_) instead of the default (_e.g. `fr-fr/articles`_).

```js
{
    defaultLang: 'en-us',
    langs: ['en-us', 'fr-fr', 'es-es'],
    shortenUrlLangs: true,
    // [...]
}
```

Quite useful when the existing site you're migrating to `gatsby-source-prismic-graphql` already has URLs with 2-char language codes live in production 😛 