### PR TITLE
fix(gatsby-ssr): reverse access token condition

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
@@ -6,7 +6,7 @@ interface OnRenderBodyArgs {
 }
 
 exports.onRenderBody = ({ setHeadComponents }: OnRenderBodyArgs, options: PluginOptions) => {
-  const accessToken = options.previews ? null : options.accessToken;
+  const accessToken = options.previews ? options.accessToken : null;
 
   const components = [
     <script


### PR DESCRIPTION
Hello 👋 

Regarding : 
- https://github.com/birkir/gatsby-source-prismic-graphql/issues/104
- https://github.com/birkir/gatsby-source-prismic-graphql/issues/45#issuecomment-539366240

It resolves the risk of unwanted exposed credentials.

Thanks. 