### PR TITLE
feat: optimize query size

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/utils/index.ts
+++ b/packages/gatsby-source-prismic-graphql/src/utils/index.ts
@@ -49,6 +49,8 @@ export function fetchStripQueryWhitespace(url: string, ...args: any) {
         .replace(/\s?\:\s?/g, ':')
         .replace(/\s?\(\s?/g, '(')
         .replace(/\s?\)\s?/g, ')')
+        .replace(/\.\.\.\s/g, '...')
+        .replace(/\,\s/g, ',')
     );
   }
   const updatedQs = Array.from(queryString)

--- a/packages/gatsby-source-prismic-graphql/src/utils/index.ts
+++ b/packages/gatsby-source-prismic-graphql/src/utils/index.ts
@@ -44,6 +44,11 @@ export function fetchStripQueryWhitespace(url: string, ...args: any) {
       String(queryString.get('query'))
         .replace(/\#.*\n/g, '')
         .replace(/\s+/g, ' ')
+        .replace(/\s?\{\s?/g, '{')
+        .replace(/\s?\}\s?/g, '}')
+        .replace(/\s?\:\s?/g, ':')
+        .replace(/\s?\(\s?/g, '(')
+        .replace(/\s?\)\s?/g, ')')
     );
   }
   const updatedQs = Array.from(queryString)


### PR DESCRIPTION
Optimizations performed:
- remove spaces around `{` and `}`
  ```
  query Q { foo }
  ```
  becomes:
  ```
  query Q{foo}
  ```
- remove space around `:`
  ```
  query Q(var : "bar") { foo }
  ```
  becomes:
  ```
  query Q(var:"bar") { foo }
  ```
- remove space around `(` and `)`
  ```
  query Q ( var: "bar" ) { foo }
  ```
  becomes:
  ```
  query Q(var: "bar"){ foo }
  ```

This optimization was developed due to a prismic limitation on huge queries:
when performing a big query I receive a "414 Request-URI Too Large" from prismic API.

refs:
https://github.com/birkir/gatsby-source-prismic-graphql/issues/15