### PR TITLE
fix: stripSharp behavior during preview mode

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
@@ -25,9 +25,10 @@ const stripSharp = (query: any) => {
       x.kind == 'Name' &&
       this.parent &&
       this.parent.node.kind === 'Field' &&
-      x.value.match(/Sharp$/)
+      x.value.match(/Sharp$/) &&
+      !x.value.match(/.+childImageSharp$/)
     ) {
-      this.parent.delete();
+      this.parent.remove();
     }
   });
 };


### PR DESCRIPTION
This commit is for fixing `stripSharp` behavior for preview mode. Previously, since it used `delete()` method, the array length of the parent didn't change, then Apollo client was struggled to handle the `query` object. Also, more previously (v3.3.1) it had used `remove()` which is proper method but filter function allowed to run it on `childImageSharp` node, thus it had worked strangely that an wrong element was removed from the array if the `***Sharp` field was not the last element when only in preview mode (probably because of difference of `this` behavior between node.js and browser, but I'm not sure).

Now, I fixed the filter function to skip `childImageSharp` node and used `remove()` method so that this plugin can work any case.

~~To check the regex solely, see https://regex101.com/r/p8DbYv/1/tests~~ This regex only works with Chrome and Node.js. I've changed it to more readable and able to work with Firefox and Safari.