### PR TITLE
fix: bump dep version to fix ERROR #11321

### DIFF
--- a/packages/gatsby-source-prismic-graphql/package.json
+++ b/packages/gatsby-source-prismic-graphql/package.json
@@ -33,7 +33,7 @@
     "apollo-link-context": "^1.0.17",
     "gatsby-image": "^2.2.4",
     "gatsby-source-filesystem": "^2.1.2",
-    "gatsby-source-graphql": "^2.0.15",
+    "gatsby-source-graphql": "^2.1.32",
     "gatsby-source-graphql-universal": "^3.1.6",
     "path-to-regexp": "^3.0.0",
     "prismic-javascript": "^2.1.1",


### PR DESCRIPTION
I was getting the following when building
```
 ERROR #11321  PLUGIN
```
The solution is discussed here https://github.com/gatsbyjs/gatsby/issues/20015