### PR TITLE
fix: sanitize accessToken option

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -8,6 +8,14 @@ import pathToRegexp from 'path-to-regexp';
 
 exports.onCreateWebpackConfig = onCreateWebpackConfig;
 
+let accessToken: string | null | undefined;
+exports.onPreInit = (_: any, options: PluginOptions) => {
+  accessToken = options.accessToken;
+  if (!options.previews) {
+    delete options.accessToken;
+  }
+};
+
 exports.onCreatePage = ({ page, actions }: any) => {
   const rootQuery = getRootQuery(page.componentPath);
   page.context = page.context || {};
@@ -25,7 +33,7 @@ exports.sourceNodes = (ref: any, options: PluginOptions) => {
       PrismicLink({
         uri: `https://${options.repositoryName}.prismic.io/graphql`,
         credentials: 'same-origin',
-        accessToken: options.accessToken as any,
+        accessToken: accessToken as any,
         customRef: options.prismicRef as any,
       }),
     ...options,

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
@@ -6,8 +6,6 @@ interface OnRenderBodyArgs {
 }
 
 exports.onRenderBody = ({ setHeadComponents }: OnRenderBodyArgs, options: PluginOptions) => {
-  const accessToken = options.previews ? null : options.accessToken;
-
   const components = [
     <script
       key="prismic-config"
@@ -16,7 +14,7 @@ exports.onRenderBody = ({ setHeadComponents }: OnRenderBodyArgs, options: Plugin
             window.prismic = {
               endpoint: 'https://${options.repositoryName}.prismic.io/api/v2',
             };
-            window.prismicGatsbyOptions = ${JSON.stringify({ ...options, accessToken })};
+            window.prismicGatsbyOptions = ${JSON.stringify(options)};
           `,
       }}
     />,


### PR DESCRIPTION
Only sourceNodes is allowed to use accessToken when previews are off

It appears that in the presence of gatsby-browser.js, all plugin options are included in the js bundle. In order to prevent inclusion of the access token in public files, it must be removed from the options object early in the build process.