### PR TITLE
Replace import for lodash with path imports

### DIFF
--- a/examples/arnaud/src/components/blogpost.js
+++ b/examples/arnaud/src/components/blogpost.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { RichText } from 'prismic-reactjs';
 import { graphql } from 'gatsby';
 import { linkResolver } from '../prismic/linkResolver';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 export const query = graphql`
   query BlogPost($uid: String) {

--- a/examples/languages/src/templates/home.js
+++ b/examples/languages/src/templates/home.js
@@ -1,7 +1,7 @@
 import { Link, graphql } from 'gatsby';
 import React from 'react';
 import Layout from '../components/layout';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { RichText } from 'prismic-reactjs';
 
 export const query = graphql`

--- a/examples/pagination/src/pages/index.js
+++ b/examples/pagination/src/pages/index.js
@@ -1,5 +1,5 @@
 import { graphql, Link } from 'gatsby';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import React, { useEffect, useRef } from 'react';
 import { getCursorFromDocumentIndex } from 'gatsby-source-prismic-graphql';
 import Layout from '../components/layout';

--- a/examples/pagination/src/templates/article.js
+++ b/examples/pagination/src/templates/article.js
@@ -1,6 +1,6 @@
 import { graphql, Link } from 'gatsby';
 import { linkResolver } from 'gatsby-source-prismic-graphql';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { RichText } from 'prismic-reactjs';
 import React from 'react';
 import Layout from '../components/layout';

--- a/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
@@ -1,5 +1,6 @@
 import { getIsolatedQuery } from 'gatsby-source-graphql-universal';
-import { pick, get } from 'lodash';
+import pick from 'lodash/pick';
+import get from 'lodash/get';
 import pathToRegexp from 'path-to-regexp';
 import Prismic from 'prismic-javascript';
 import React from 'react';


### PR DESCRIPTION
Changing Lodash to use a path import reduce bundle size by 60Kb.

#141 

![Screenshot 2020-02-22 at 3 16 00 AM](https://user-images.githubusercontent.com/990517/75064357-bf4d0900-5521-11ea-88c8-8bea7082fd70.png)
