### PR TITLE
Add `extraPageFields` to `AllPagesQuery` for better filtering

### DIFF
--- a/packages/gatsby-source-prismic-graphql/README.md
+++ b/packages/gatsby-source-prismic-graphql/README.md
@@ -64,6 +64,7 @@ yarn add gatsby-source-prismic-graphql
       component: require.resolve('./src/templates/article.js'),
       sortBy: 'date_ASC', // optional, default: meta_lastPublicationDate_ASC; useful for pagination
     }],
+    extraPageFields: 'article_type', // optional, extends pages query to pass extra fields
     sharpKeys: [
       /image|photo|picture/, // (default)
       'profilepic',
@@ -140,6 +141,34 @@ Given 3 articles with UIDs of `why-i-like-music`, `why-i-like-sports` and `why-i
 - `/musicblog/why-i-like-music`
 - `/blog/why-i-like-sports`
 - `/blog/why-i-like-food`
+
+### Generating pages from page fields
+
+Sometimes the meta provided by default doesn't contain enough context to be able to filter pages effectively. By passing `extraPageFields` to the plugin options, we can extend what we can filter on.
+
+```js
+{
+  extraPageFields: 'music_genre',
+  pages: [{
+    type: 'Article',
+    match: '/techno/:uid',
+    filter: data => data.node.music_genre === 'techno',
+    path: '/blogposts',
+    component: require.resolve('./src/templates/article.js'),
+  }, {
+    type: 'Article',
+    match: '/acoustic/:uid',
+    filter: data => data.node.music_genre === 'acoustic',
+    path: '/blogposts',
+    component: require.resolve('./src/templates/article.js'),
+  }]
+}
+```
+
+Given 2 articles with the `music_genre` field set, we'll get the following slugs:
+
+/techno/darude
+/acoustic/mik-parsons
 
 ### Support for Multiple Languages
 

--- a/packages/gatsby-source-prismic-graphql/package.json
+++ b/packages/gatsby-source-prismic-graphql/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/birkir/gatsby-source-prismic-graphql/issues"
   },
-  "version": "3.4.0",
+  "version": "3.5.0",
   "main": "index.js",
   "files": [
     "*.js",

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -134,9 +134,11 @@ function createDocumentPages(
 const getDocumentsQuery = ({
   documentType,
   sortType,
+  extraPageFields,
 }: {
   documentType: string;
   sortType: string;
+  extraPageFields: string;
 }): string => `
   query AllPagesQuery ($after: String, $lang: String, $sortBy: ${sortType}) {
     prismic {
@@ -154,6 +156,7 @@ const getDocumentsQuery = ({
         edges {
           cursor
           node {
+            ${extraPageFields}
             _meta {
               id
               lang
@@ -190,7 +193,8 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     // Prepare and execute query
     const documentType: string = `all${page.type}s`;
     const sortType: string = `PRISMIC_Sort${page.type}y`;
-    const query: string = getDocumentsQuery({ documentType, sortType });
+    const extraPageFields = options.extraPageFields || '';
+    const query: string = getDocumentsQuery({ documentType, sortType, extraPageFields });
     const { data, errors } = await graphql(query, {
       after: endCursor,
       lang: lang || null,

--- a/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
+++ b/packages/gatsby-source-prismic-graphql/src/interfaces/PluginOptions.ts
@@ -22,4 +22,5 @@ export interface PluginOptions {
   pages?: Page[];
   omitPrismicScript?: boolean;
   sharpKeys: RegExp[] | string[];
+  extraPageFields: string;
 }


### PR DESCRIPTION
We want to make use of the `filter` functionality to be able to build pages based on a field added to a Prismic page or custom type. Filtering on `_meta` is useful, but being able to define a field or fields that can be filtered on is more powerful.

### What has changed?
- `extraPageFields` is an option on `PluginOptions`
- That is passed to `getDocumentsQuery`
- And injected in `AllPagesQuery` for each page node

### How to test this?
- Add a field to one of your examples
- Add the field to `PluginOptions.extraPageFields` 
- Add to the filter to check the field