### PR TITLE
Passes parent props through to wrapped element

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
@@ -141,9 +141,15 @@ export class WrapPage extends React.PureComponent<any, WrapPageState> {
   };
 
   render() {
-    const children = this.props.children as any;
+    const props = this.props as { children: any, options: any, [key: string]: any}
+
+    // we need to pass the parent props to the child
+    // but we don't want to pass the prismic options or the children props
+    // so exclude those and take everything else
+    const { children, options, ...elProps } = props
 
     return React.cloneElement(children, {
+      ...elProps,
       ...children.props,
       prismic: {
         options: this.props.options,


### PR DESCRIPTION
Closes #169 

When two plugins are both using `wrapPageElement` they may be passing their own props to that element. If those are not passed on to the children they are wrapping, those props are lost. In issue #169 I've been using [gatsby-plugin-transition-link](https://github.com/TylerBarnes/gatsby-plugin-transition-link) which adds `transitionStatus` to each page. But if `gatsby-source-prismic-graphql` wraps the component after `gatsby-plugin-transition-link` then this is lost.

This fix ensures that any props that come from a parent wrapped component are passed down to any children which are also being wrapped.