### PR TITLE
fix: preview not working

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
@@ -135,7 +135,7 @@ export class WrapPage extends React.PureComponent<any, WrapPageState> {
     return getApolloClient(this.props.options).then(client => {
       return client.query({
         query: stripSharp(getIsolatedQuery(query, fieldName, typeName)),
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'no-cache',
         variables,
         ...rest,
       });

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -4,9 +4,7 @@ import { onCreateWebpackConfig, sourceNodes } from 'gatsby-source-graphql-univer
 import { flatten, fieldName, PrismicLink, typeName, getPagePreviewPath } from './utils';
 import { Page, PluginOptions } from './interfaces/PluginOptions';
 import { createRemoteFileNode } from 'gatsby-source-filesystem';
-
 import { pathToRegexp, compile as compilePath, Key } from 'path-to-regexp';
-import querystring from 'querystring';
 
 interface Edge {
   cursor: string;
@@ -303,7 +301,7 @@ exports.createResolvers = (
             const url = args.crop ? obj[args.crop] && obj[args.crop].url : obj.url;
             if (url) {
               return createRemoteFileNode({
-                url: querystring.unescape(url),
+                url,
                 store,
                 cache,
                 createNode,


### PR DESCRIPTION
Fixes: #154.

Also revert: #143 which broke image urls. See issue [here](https://github.com/birkir/gatsby-source-prismic-graphql/pull/143#issuecomment-595680469).