### PR TITLE
Bugfix/format page type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
+- fix useStaticQuery hook [#77](https://github.com/birkir/gatsby-source-prismic-graphql/issues/77) ([ba15d2b](https://github.com/birkir/gatsby-source-prismic-graphql/commit/ba15d2bf50d63593449c48f54a8c0009c6510e45))
 - bump dep version to fix ERROR [#11321](https://github.com/birkir/gatsby-source-prismic-graphql/issues/11321) ([9500260](https://github.com/birkir/gatsby-source-prismic-graphql/commit/9500260c0cc81600e1b013b7e115275293ed0e89))
 - change travis build to deploy stable version ([46854b8](https://github.com/birkir/gatsby-source-prismic-graphql/commit/46854b8af8b2fe90e8f944060be792eb75042448))
 - fix post review ([9ecc671](https://github.com/birkir/gatsby-source-prismic-graphql/commit/9ecc6711116c05b4002c859ac77beeebe2164e73))
 - fixing type & updating path-to-regexp to use new match function ([eff64d8](https://github.com/birkir/gatsby-source-prismic-graphql/commit/eff64d824438690b7c73ced8f923b5c2f661412d))
 - handle pages with unicode characters ([fa698d5](https://github.com/birkir/gatsby-source-prismic-graphql/commit/fa698d56de2b539f237b18debad6752a92a3524c))
 - multi-lang previews ([e4baba7](https://github.com/birkir/gatsby-source-prismic-graphql/commit/e4baba7bc2c5295bdbb9d20f083891dd127165b1))
-- rollback code to older typescript version ([3cbb1f1](https://github.com/birkir/gatsby-source-prismic-graphql/commit/3cbb1f1d62c7fa97ca44d69e1d205423be50d118))
 - sanitize accessToken option ([6cb96bf](https://github.com/birkir/gatsby-source-prismic-graphql/commit/6cb96bf37f6b258ebda817c06c6a5ab0c3dbc178))
 - test if page exists to display preview real url ([8705eb9](https://github.com/birkir/gatsby-source-prismic-graphql/commit/8705eb99352fda6aab41a684a25d9f16ef86e836))
 - unescape createRemoteFileNode url ([018efe2](https://github.com/birkir/gatsby-source-prismic-graphql/commit/018efe287d25c1750cfb1e69564a3ca670e693b1))
 - unpublish preview for Multi-language ([9ec4f89](https://github.com/birkir/gatsby-source-prismic-graphql/commit/9ec4f896b64f79bae3415419deb671a6db6dff3e))
 - update function doc ([0bb6b35](https://github.com/birkir/gatsby-source-prismic-graphql/commit/0bb6b3550766313624c751fb2369207471301d3c))
-- update yarn lock so we can publish ([4736559](https://github.com/birkir/gatsby-source-prismic-graphql/commit/473655989804f046d99effb5b0491335300c19f9))
 
 ### Features
 

--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -211,9 +211,12 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     endCursor: string = '',
     documents: Edge[] = []
   ): Promise<Edge[]> {
+    // Format page.type so that the graphql query doesn't complain.
+    const pageTypeUnderscored = page.type.toLowerCase().split(' ').join('_');
+    const pageTypeFormatted = pageTypeUnderscored.charAt(0).toUpperCase() + pageTypeUnderscored.slice(1);
     // Prepare and execute query
-    const documentType: string = `all${page.type}s`;
-    const sortType: string = `PRISMIC_Sort${page.type}y`;
+    const documentType: string = `all${pageTypeFormatted}s`;
+    const sortType: string = `PRISMIC_Sort${pageTypeFormatted}y`;
     const extraPageFields = options.extraPageFields || '';
     const query: string = getDocumentsQuery({ documentType, sortType, extraPageFields });
     const { data, errors } = await graphql(query, {


### PR DESCRIPTION
Should fix the following issue: https://github.com/birkir/gatsby-source-prismic-graphql/issues/200#issuecomment-630947309

As I wrote in the comments, the issue is that the page type that's seen in the prismic dashboard, doesn't correspond to the one used by graphql. So I've added formatting to the string, so that the user doesn't have to care about this.