### PR TITLE
imageSharp keys were not being removed on preview query

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/components/WrapPage.tsx
@@ -31,7 +31,7 @@ const stripSharp = (query: any) => {
       x.value.match(/Sharp$/) &&
       !x.value.match(/.+childImageSharp$/)
     ) {
-      this.parent.remove();
+      this.parent.delete();
     }
   });
 };


### PR DESCRIPTION
fixed issue where imageSharp keys were not being removed from graphql query on previews causing a 500 error.