### PR TITLE
Fix broken builds by removing `y` from `sortType`

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-node.ts
@@ -217,7 +217,7 @@ exports.createPages = async ({ graphql, actions: { createPage } }: any, options:
     const pageTypeFormatted = pageTypeUnderscored.charAt(0).toUpperCase() + pageTypeUnderscored.slice(1);
     // Prepare and execute query
     const documentType: string = `all${pageTypeFormatted}s`;
-    const sortType: string = `PRISMIC_Sort${pageTypeFormatted}y`;
+    const sortType: string = `PRISMIC_Sort${pageTypeFormatted}`;
     const extraPageFields = options.extraPageFields || '';
     const query: string = getDocumentsQuery({ documentType, sortType, extraPageFields });
     const { data, errors } = await graphql(query, {


### PR DESCRIPTION
My builds have suddenly started breaking without this.  Don't ask me why it's necessary... I'm guessing Prismic changed their API?  Can anyone else confirm?

Example of the change in types I'm seeing: `PRISMIC_SortBlog_posty` has become `PRISMIC_SortBlog_post`.