### PR TITLE
fix: add new flag to prismic.min.js

### DIFF
--- a/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
+++ b/packages/gatsby-source-prismic-graphql/src/gatsby-ssr.tsx
@@ -25,7 +25,7 @@ exports.onRenderBody = ({ setHeadComponents }: OnRenderBodyArgs, options: Plugin
       <script
         key="prismic-script"
         type="text/javascript"
-        src="//static.cdn.prismic.io/prismic.min.js"
+        src="//static.cdn.prismic.io/prismic.min.js?new=true"
       />
     );
   }


### PR DESCRIPTION
Upgrades prismic.min.js to newer version that resolves issue with inability to close prismic-preview library in Chrome

Issue is described here: https://community.prismic.io/t/cant-close-the-preview-module-chrome/1707/21